### PR TITLE
chore(import_guard): prepare for pub.dev publishing

### DIFF
--- a/packages/import_guard/CHANGELOG.md
+++ b/packages/import_guard/CHANGELOG.md
@@ -1,0 +1,8 @@
+## 0.1.0
+
+- Initial release
+- Define import restrictions per folder using `import_guard.yaml`
+- Glob patterns: `**` (all descendants), `*` (direct children only)
+- Package imports: `package:my_app/data/**`
+- External packages: `package:flutter/**`, `dart:mirrors`
+- Configurable severity (error/warning/info) via `analysis_options.yaml`

--- a/packages/import_guard/pubspec.yaml
+++ b/packages/import_guard/pubspec.yaml
@@ -1,7 +1,13 @@
 name: import_guard
-description: A custom_lint package to guard imports between packages/folders.
-version: 0.0.1
-publish_to: none
+description: A custom_lint package to guard imports between folders. Enforce clean architecture layer dependencies with configurable deny rules.
+version: 0.1.0
+repository: https://github.com/ryota-kishimoto/packages/tree/main/packages/import_guard
+issue_tracker: https://github.com/ryota-kishimoto/packages/issues
+topics:
+  - lints
+  - lint
+  - clean-architecture
+  - static-analysis
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
## Summary
- Remove `publish_to: none` from pubspec.yaml
- Add repository and issue_tracker URLs
- Bump version to 0.1.0
- Add CHANGELOG.md

## After merge
```bash
cd packages/import_guard
dart pub login
dart pub publish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)