### PR TITLE
chore: update repository URLs, simplify core README, bump core to 0.0.2

### DIFF
--- a/packages/import_guard/example/pubspec.lock
+++ b/packages/import_guard/example/pubspec.lock
@@ -105,11 +105,12 @@ packages:
     source: path
     version: "0.0.1"
   import_guard_core:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../import_guard_core"
-      relative: true
-    source: path
+      name: import_guard_core
+      sha256: "4f52ca21936c6a3ce4dbb5379ba648733b37e4d20cf763148776aaf83d37765a"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.0.1"
   meta:
     dependency: transitive

--- a/packages/import_guard/example/pubspec_overrides.yaml
+++ b/packages/import_guard/example/pubspec_overrides.yaml
@@ -1,6 +1,0 @@
-# melos_managed_dependency_overrides: import_guard,import_guard_core
-dependency_overrides:
-  import_guard:
-    path: ..
-  import_guard_core:
-    path: ../../import_guard_core

--- a/packages/import_guard/pubspec.lock
+++ b/packages/import_guard/pubspec.lock
@@ -100,9 +100,10 @@ packages:
   import_guard_core:
     dependency: "direct main"
     description:
-      path: "../import_guard_core"
-      relative: true
-    source: path
+      name: import_guard_core
+      sha256: "4f52ca21936c6a3ce4dbb5379ba648733b37e4d20cf763148776aaf83d37765a"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.0.1"
   meta:
     dependency: transitive

--- a/packages/import_guard/pubspec.yaml
+++ b/packages/import_guard/pubspec.yaml
@@ -1,8 +1,8 @@
 name: import_guard
 description: An analyzer plugin to guard imports between folders. Enforce clean architecture layer dependencies with configurable deny rules.
 version: 0.0.1
-repository: https://github.com/ryota-kishimoto/packages/tree/main/packages/import_guard
-issue_tracker: https://github.com/ryota-kishimoto/packages/issues
+repository: https://github.com/ryota-kishimoto/import_guard/tree/main/packages/import_guard
+issue_tracker: https://github.com/ryota-kishimoto/import_guard/issues
 topics:
   - lints
   - lint

--- a/packages/import_guard/pubspec_overrides.yaml
+++ b/packages/import_guard/pubspec_overrides.yaml
@@ -1,3 +1,0 @@
-dependency_overrides:
-  import_guard_core:
-    path: ../import_guard_core

--- a/packages/import_guard_core/CHANGELOG.md
+++ b/packages/import_guard_core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.2
+
+- Update repository URL
+- Simplify README
+
 ## 0.0.1
 
 - Initial release

--- a/packages/import_guard_core/README.md
+++ b/packages/import_guard_core/README.md
@@ -2,34 +2,8 @@
 
 Core logic for import_guard - pattern matching and configuration parsing.
 
-This package is used internally by `import_guard` and `import_guard_custom_lint`.
+This package is used internally by [`import_guard`](https://pub.dev/packages/import_guard) and [`import_guard_custom_lint`](https://pub.dev/packages/import_guard_custom_lint).
 
-## Features
+## License
 
-- `PatternTrie`: Efficient O(path_length) pattern matching using Trie data structure
-- `PatternMatcher`: Glob pattern matching (`*`, `**`) for imports
-- `ConfigCache`: Cached configuration loading from `import_guard.yaml` files
-- `ImportGuardConfig`: Configuration model with deny patterns
-
-## Usage
-
-```dart
-import 'package:import_guard_core/import_guard_core.dart';
-
-// Pattern matching with Trie
-final trie = PatternTrie()
-  ..insert('package:my_app/data/**')
-  ..insert('dart:mirrors');
-
-print(trie.matches('package:my_app/data/repo.dart')); // true
-print(trie.matches('dart:mirrors')); // true
-
-// Configuration loading
-final configCache = ConfigCache();
-final configs = configCache.getConfigsForFile(filePath, packageRoot);
-```
-
-## Related Packages
-
-- [import_guard](https://pub.dev/packages/import_guard) - Native analyzer plugin (Dart 3.10+)
-- [import_guard_custom_lint](https://pub.dev/packages/import_guard_custom_lint) - custom_lint implementation (Dart 3.6+)
+MIT

--- a/packages/import_guard_core/pubspec.yaml
+++ b/packages/import_guard_core/pubspec.yaml
@@ -1,8 +1,8 @@
 name: import_guard_core
 description: Core logic for import_guard - pattern matching and configuration parsing.
-version: 0.0.1
-repository: https://github.com/ryota-kishimoto/packages/tree/main/packages/import_guard_core
-issue_tracker: https://github.com/ryota-kishimoto/packages/issues
+version: 0.0.2
+repository: https://github.com/ryota-kishimoto/import_guard/tree/main/packages/import_guard_core
+issue_tracker: https://github.com/ryota-kishimoto/import_guard/issues
 topics:
   - lints
   - clean-architecture

--- a/packages/import_guard_custom_lint/example/pubspec.lock
+++ b/packages/import_guard_custom_lint/example/pubspec.lock
@@ -178,19 +178,20 @@ packages:
     source: hosted
     version: "4.3.0"
   import_guard_core:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../import_guard_core"
-      relative: true
-    source: path
-    version: "1.0.0"
+      name: import_guard_core
+      sha256: "4f52ca21936c6a3ce4dbb5379ba648733b37e4d20cf763148776aaf83d37765a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
   import_guard_custom_lint:
     dependency: "direct dev"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "0.0.1"
   json_annotation:
     dependency: transitive
     description:

--- a/packages/import_guard_custom_lint/example/pubspec_overrides.yaml
+++ b/packages/import_guard_custom_lint/example/pubspec_overrides.yaml
@@ -1,5 +1,0 @@
-dependency_overrides:
-  import_guard_custom_lint:
-    path: ..
-  import_guard_core:
-    path: ../../import_guard_core

--- a/packages/import_guard_custom_lint/pubspec.lock
+++ b/packages/import_guard_custom_lint/pubspec.lock
@@ -220,9 +220,10 @@ packages:
   import_guard_core:
     dependency: "direct main"
     description:
-      path: "../import_guard_core"
-      relative: true
-    source: path
+      name: import_guard_core
+      sha256: "4f52ca21936c6a3ce4dbb5379ba648733b37e4d20cf763148776aaf83d37765a"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.0.1"
   io:
     dependency: transitive

--- a/packages/import_guard_custom_lint/pubspec.yaml
+++ b/packages/import_guard_custom_lint/pubspec.yaml
@@ -1,8 +1,8 @@
 name: import_guard_custom_lint
 description: A custom_lint package to guard imports between folders. Enforce clean architecture layer dependencies with configurable deny rules.
 version: 0.0.1
-repository: https://github.com/ryota-kishimoto/packages/tree/main/packages/import_guard_custom_lint
-issue_tracker: https://github.com/ryota-kishimoto/packages/issues
+repository: https://github.com/ryota-kishimoto/import_guard/tree/main/packages/import_guard_custom_lint
+issue_tracker: https://github.com/ryota-kishimoto/import_guard/issues
 topics:
   - lints
   - lint

--- a/packages/import_guard_custom_lint/pubspec_overrides.yaml
+++ b/packages/import_guard_custom_lint/pubspec_overrides.yaml
@@ -1,3 +1,0 @@
-dependency_overrides:
-  import_guard_core:
-    path: ../import_guard_core


### PR DESCRIPTION
## Summary

- Update repository and issue_tracker URLs from `packages` to `import_guard`
- Simplify `import_guard_core` README (remove usage section - internal package)
- Bump `import_guard_core` version to 0.0.2
- Remove `pubspec_overrides.yaml` files (local dev only)
- Update `pubspec.lock` files to use pub.dev instead of local paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)