### PR TITLE
chore: update import_guard_core dependency to ^0.0.2

### DIFF
--- a/packages/import_guard/example/pubspec.lock
+++ b/packages/import_guard/example/pubspec.lock
@@ -108,10 +108,10 @@ packages:
     dependency: transitive
     description:
       name: import_guard_core
-      sha256: "4f52ca21936c6a3ce4dbb5379ba648733b37e4d20cf763148776aaf83d37765a"
+      sha256: "0333b023e59e1e64cf4f2111170e2e677dc969662bc61ac7f857a7ea85e376e7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1"
+    version: "0.0.2"
   meta:
     dependency: transitive
     description:

--- a/packages/import_guard/pubspec.lock
+++ b/packages/import_guard/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: "direct main"
     description:
       name: import_guard_core
-      sha256: "4f52ca21936c6a3ce4dbb5379ba648733b37e4d20cf763148776aaf83d37765a"
+      sha256: "0333b023e59e1e64cf4f2111170e2e677dc969662bc61ac7f857a7ea85e376e7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1"
+    version: "0.0.2"
   meta:
     dependency: transitive
     description:

--- a/packages/import_guard/pubspec.yaml
+++ b/packages/import_guard/pubspec.yaml
@@ -15,4 +15,4 @@ environment:
 dependencies:
   analysis_server_plugin: ^0.3.0
   analyzer: ^8.0.0
-  import_guard_core: ^0.0.1
+  import_guard_core: ^0.0.2

--- a/packages/import_guard_custom_lint/example/pubspec.lock
+++ b/packages/import_guard_custom_lint/example/pubspec.lock
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: import_guard_core
-      sha256: "4f52ca21936c6a3ce4dbb5379ba648733b37e4d20cf763148776aaf83d37765a"
+      sha256: "0333b023e59e1e64cf4f2111170e2e677dc969662bc61ac7f857a7ea85e376e7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1"
+    version: "0.0.2"
   import_guard_custom_lint:
     dependency: "direct dev"
     description:

--- a/packages/import_guard_custom_lint/pubspec.lock
+++ b/packages/import_guard_custom_lint/pubspec.lock
@@ -221,10 +221,10 @@ packages:
     dependency: "direct main"
     description:
       name: import_guard_core
-      sha256: "4f52ca21936c6a3ce4dbb5379ba648733b37e4d20cf763148776aaf83d37765a"
+      sha256: "0333b023e59e1e64cf4f2111170e2e677dc969662bc61ac7f857a7ea85e376e7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1"
+    version: "0.0.2"
   io:
     dependency: transitive
     description:

--- a/packages/import_guard_custom_lint/pubspec.yaml
+++ b/packages/import_guard_custom_lint/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   analyzer: ^8.0.0
   analyzer_plugin: ^0.13.0
   custom_lint_builder: ^0.8.0
-  import_guard_core: ^0.0.1
+  import_guard_core: ^0.0.2
 
 dev_dependencies:
   test: ^1.25.0


### PR DESCRIPTION
## Summary

Update `import_guard_core` dependency from `^0.0.1` to `^0.0.2` in:
- `import_guard`
- `import_guard_custom_lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)