### PR TITLE
fix: share config cache across packages in monorepo

### DIFF
--- a/packages/import_guard/pubspec.yaml
+++ b/packages/import_guard/pubspec.yaml
@@ -15,4 +15,4 @@ environment:
 dependencies:
   analysis_server_plugin: ^0.3.0
   analyzer: ^8.0.0
-  import_guard_core: ^0.0.2
+  import_guard_core: ^0.0.3

--- a/packages/import_guard_core/CHANGELOG.md
+++ b/packages/import_guard_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.3
+
+- Fix: share config cache across packages in monorepo (performance improvement)
+
 ## 0.0.2
 
 - Update repository URL

--- a/packages/import_guard_core/pubspec.yaml
+++ b/packages/import_guard_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: import_guard_core
 description: Core logic for import_guard - pattern matching and configuration parsing.
-version: 0.0.2
+version: 0.0.3
 repository: https://github.com/ryota-kishimoto/import_guard/tree/main/packages/import_guard_core
 issue_tracker: https://github.com/ryota-kishimoto/import_guard/issues
 topics:

--- a/packages/import_guard_custom_lint/pubspec.yaml
+++ b/packages/import_guard_custom_lint/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   analyzer: ^8.0.0
   analyzer_plugin: ^0.13.0
   custom_lint_builder: ^0.8.0
-  import_guard_core: ^0.0.2
+  import_guard_core: ^0.0.3
 
 dev_dependencies:
   test: ^1.25.0


### PR DESCRIPTION
## Problem

Monorepo で各パッケージごとに repo 全体をスキャンしていた。
例: presenter, ui, domain パッケージがあると、3回同じ repo をスキャンする。

## Solution

`repoRoot` ごとにキャッシュを共有するように変更。
同じ repo 内の複数パッケージでスキャン結果を再利用。

## Changes

- `import_guard_core` 0.0.3
- `import_guard`, `import_guard_custom_lint` の依存を `^0.0.3` に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)