### PR TITLE
fix: correct SDK constraints and add WARNING severity to LintCode

### DIFF
--- a/packages/import_guard/CHANGELOG.md
+++ b/packages/import_guard/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.4
+
+- Fix: lower SDK constraint to ^3.9.0 (was ^3.10.0)
+- Fix: add WARNING severity to LintCode to match registerWarningRule()
+
 ## 0.0.3
 
 - Fix: monorepo performance improvement (share config cache across packages)
@@ -7,7 +12,7 @@
 ## 0.0.1
 
 - Initial release
-- Native analyzer plugin using analysis_server_plugin (Dart 3.10+)
+- Native analyzer plugin using analysis_server_plugin (Dart 3.9+)
 - Full IDE integration with `dart analyze` and `flutter analyze`
 - Support for glob patterns (`*`, `**`)
 - Hierarchical config inheritance from repo root

--- a/packages/import_guard/lib/src/import_guard_rule.dart
+++ b/packages/import_guard/lib/src/import_guard_rule.dart
@@ -4,6 +4,7 @@ import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/error.dart';
+import 'package:analyzer/src/dart/error/lint_codes.dart' show DiagnosticSeverity;
 import 'package:import_guard_core/import_guard_core.dart';
 
 /// An analyzer rule that guards imports based on import_guard.yaml configuration.
@@ -11,6 +12,7 @@ class ImportGuardRule extends AnalysisRule {
   static const LintCode code = LintCode(
     'import_guard',
     'This import is not allowed: {0}',
+    severity: DiagnosticSeverity.WARNING,
   );
 
   ImportGuardRule()

--- a/packages/import_guard/pubspec.yaml
+++ b/packages/import_guard/pubspec.yaml
@@ -1,6 +1,6 @@
 name: import_guard
 description: An analyzer plugin to guard imports between folders. Enforce clean architecture layer dependencies with configurable deny rules.
-version: 0.0.3
+version: 0.0.4
 repository: https://github.com/ryota-kishimoto/import_guard/tree/main/packages/import_guard
 issue_tracker: https://github.com/ryota-kishimoto/import_guard/issues
 topics:
@@ -10,9 +10,9 @@ topics:
   - static-analysis
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.9.0
 
 dependencies:
   analysis_server_plugin: ^0.3.0
   analyzer: ^8.0.0
-  import_guard_core: ^0.0.3
+  import_guard_core: ^0.0.4

--- a/packages/import_guard_core/CHANGELOG.md
+++ b/packages/import_guard_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.4
+
+- Fix: correct SDK constraint to >=3.7.0 (was incorrectly set to ^3.6.0)
+
 ## 0.0.3
 
 - Fix: share config cache across packages in monorepo (performance improvement)

--- a/packages/import_guard_core/pubspec.yaml
+++ b/packages/import_guard_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: import_guard_core
 description: Core logic for import_guard - pattern matching and configuration parsing.
-version: 0.0.3
+version: 0.0.4
 repository: https://github.com/ryota-kishimoto/import_guard/tree/main/packages/import_guard_core
 issue_tracker: https://github.com/ryota-kishimoto/import_guard/issues
 topics:
@@ -9,7 +9,7 @@ topics:
   - static-analysis
 
 environment:
-  sdk: ^3.6.0
+  sdk: ">=3.7.0 <4.0.0"
 
 dependencies:
   yaml: ^3.1.0

--- a/packages/import_guard_custom_lint/CHANGELOG.md
+++ b/packages/import_guard_custom_lint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.4
+
+- Fix: correct SDK constraint to >=3.7.0 (analyzer ^8.0.0 requires 3.7.0+)
+
 ## 0.0.3
 
 - Fix: monorepo performance improvement (share config cache across packages)
@@ -7,7 +11,7 @@
 ## 0.0.1
 
 - Initial release
-- custom_lint based implementation for Dart 3.6+
+- custom_lint based implementation for Dart 3.7+
 - Support for glob patterns (`*`, `**`)
 - Hierarchical config inheritance from repo root
 - Trie-based O(path_length) pattern matching

--- a/packages/import_guard_custom_lint/example/pubspec.lock
+++ b/packages/import_guard_custom_lint/example/pubspec.lock
@@ -191,7 +191,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.3"
   json_annotation:
     dependency: transitive
     description:

--- a/packages/import_guard_custom_lint/pubspec.yaml
+++ b/packages/import_guard_custom_lint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: import_guard_custom_lint
 description: A custom_lint package to guard imports between folders. Enforce clean architecture layer dependencies with configurable deny rules.
-version: 0.0.3
+version: 0.0.4
 repository: https://github.com/ryota-kishimoto/import_guard/tree/main/packages/import_guard_custom_lint
 issue_tracker: https://github.com/ryota-kishimoto/import_guard/issues
 topics:
@@ -10,13 +10,13 @@ topics:
   - static-analysis
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
+  sdk: ">=3.7.0 <4.0.0"
 
 dependencies:
   analyzer: ^8.0.0
   analyzer_plugin: ^0.13.0
   custom_lint_builder: ^0.8.0
-  import_guard_core: ^0.0.3
+  import_guard_core: ^0.0.4
 
 dev_dependencies:
   test: ^1.25.0


### PR DESCRIPTION
## Summary

- Bump all packages to 0.0.4
- `import_guard`: SDK ^3.10.0 → ^3.9.0
- `import_guard_custom_lint`: SDK >=3.6.0 → >=3.7.0
- `import_guard_core`: SDK ^3.6.0 → >=3.7.0
- Add `severity: DiagnosticSeverity.WARNING` to LintCode to match `registerWarningRule()`

## Background

The previous SDK constraint of 3.6.0 was incorrect because `analyzer ^8.0.0` requires SDK 3.7.0 or higher.

Also fixed a mismatch where the rule was registered via `registerWarningRule()` but `LintCode` defaulted to `INFO` severity.

## Test plan

- [x] `dart pub get` succeeds
- [x] `dart test` passes for import_guard_core

🤖 Generated with [Claude Code](https://claude.com/claude-code)