### PR TITLE
chore: import_guard_custom_lint 1.0.0 リリース準備

### DIFF
--- a/packages/import_guard_custom_lint/CHANGELOG.md
+++ b/packages/import_guard_custom_lint/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0
 
 - Stable release
+- Fix: `/**` glob matching similar directory prefixes
 - Sync test thresholds with import_guard package
 
 ## 0.0.8

--- a/packages/import_guard_custom_lint/example/pubspec.lock
+++ b/packages/import_guard_custom_lint/example/pubspec.lock
@@ -183,7 +183,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.1"
+    version: "1.0.0"
   json_annotation:
     dependency: transitive
     description:

--- a/packages/import_guard_custom_lint/pubspec.yaml
+++ b/packages/import_guard_custom_lint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: import_guard_custom_lint
 description: A custom_lint package to guard imports between folders. Enforce clean architecture layer dependencies with configurable deny rules.
-version: 1.0.1
+version: 1.0.0
 repository: https://github.com/ryota-kishimoto/import_guard/tree/main/packages/import_guard_custom_lint
 issue_tracker: https://github.com/ryota-kishimoto/import_guard/issues
 topics:


### PR DESCRIPTION
## 概要
- import_guard_custom_lint のバージョンを 1.0.1 → 1.0.0 に修正
- pub.dev 未公開のため、1.0.0 として初の stable リリースを行う

## 変更内容
- `pubspec.yaml`: version を 1.0.0 に設定
- `example/pubspec.lock`: バージョン参照更新

## 背景
前回のバージョンバンプ (#51) で 1.0.1 に上げたが、1.0.0 が pub.dev に未公開だった。
1.0.0 として正式リリースする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)