### PR TITLE
refactor: use final plugin field per official sample

### DIFF
--- a/packages/import_guard/lib/main.dart
+++ b/packages/import_guard/lib/main.dart
@@ -4,7 +4,7 @@ import 'package:analysis_server_plugin/registry.dart';
 import 'package:import_guard/src/import_guard_rule.dart';
 
 /// The entry point for the import_guard analyzer plugin.
-Plugin get plugin => ImportGuardPlugin();
+final Plugin plugin = ImportGuardPlugin();
 
 /// The import_guard analyzer plugin that registers lint rules.
 class ImportGuardPlugin extends Plugin {


### PR DESCRIPTION
## Summary

- `packages/import_guard/lib/main.dart` の plugin エントリポイントを getter から `final` フィールドに変更
- [`analysis_server_plugin` 公式ドキュメント](https://github.com/dart-lang/sdk/blob/main/pkg/analysis_server_plugin/doc/writing_a_plugin.md) のサンプル (`final plugin = SimplePlugin();`) に準拠
- 公式ドキュメントでは "Dart Analysis Server generates code that imports lib/main.dart and references this plugin **top-level variable**" と明記されており、getter ではなく top-level variable が要求されている

## Why

- getter はアクセスごとに新しい `ImportGuardPlugin` インスタンスを生成するが、analyzer plugin は singleton として扱われるのが想定
- 同リポジトリで参考にしている weather_linter 等も `final plugin = ...` パターン
- 外部 API (`plugin` シンボル) は保たれるため破壊的変更なし

Closes #57

## Test plan

- [ ] `dart analyze` が packages/import_guard で通ること
- [ ] 既存のテスト (`dart test`) が通ること
- [ ] サンプルプロジェクトで plugin が正常に動作すること