### PR TITLE
feat(import_guard): 0.2.0 — support analyzer 12.x

### DIFF
--- a/packages/import_guard/CHANGELOG.md
+++ b/packages/import_guard/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.0
+
+- Widen analyzer constraint to support `>=8.2.0 <13.0.0` (adds analyzer 12.x support)
+- Allows coexistence with other analyzer plugins pinned to analyzer 12.x
+
 ## 0.1.0
 
 - Widen analyzer constraint to support >=8.2.0 <12.0.0

--- a/packages/import_guard/CHANGELOG.md
+++ b/packages/import_guard/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Widen analyzer constraint to support `>=8.2.0 <13.0.0` (adds analyzer 12.x support)
 - Allows coexistence with other analyzer plugins pinned to analyzer 12.x
+- Verified on analyzer 12.1.0 (example updated to resolve analyzer 12.x)
 
 ## 0.1.0
 

--- a/packages/import_guard/doc/version_compatibility.md
+++ b/packages/import_guard/doc/version_compatibility.md
@@ -5,8 +5,8 @@
 | Dependency | Version |
 |------------|---------|
 | Dart SDK | ^3.9.0 |
-| analysis_server_plugin | ^0.3.0 |
-| analyzer | ^8.2.0 |
+| analysis_server_plugin | >=0.3.0 <1.0.0 |
+| analyzer | >=8.2.0 <13.0.0 |
 
 ## analysis_server_plugin
 
@@ -43,12 +43,16 @@ This package uses `analysis_server_plugin`, which is the official Dart analyzer 
 
 ## analyzer version
 
-This package requires analyzer ^8.2.0, which is bundled with Dart 3.9+.
+This package supports analyzer `>=8.2.0 <13.0.0`. The upper bound is widened as
+newer analyzer majors are verified to work, so `import_guard` can coexist with
+other analyzer plugins pinned to a newer analyzer.
 
-| Dart SDK | analyzer version |
-|----------|------------------|
-| 3.9.x | 8.x |
-| 3.10.x | 8.x |
+| analyzer | supported |
+|----------|-----------|
+| 8.x | ✅ |
+| 9.x - 11.x | ✅ (within declared range) |
+| 12.x | ✅ (verified on 12.1.0) |
+| 13.x+ | ❌ (not yet verified) |
 
 ## Choosing the right package
 
@@ -63,7 +67,7 @@ This package requires analyzer ^8.2.0, which is bundled with Dart 3.9+.
 ```yaml
 # pubspec.yaml
 dev_dependencies:
-  import_guard: ^0.0.6
+  import_guard: ^0.2.0
 ```
 
 ```yaml

--- a/packages/import_guard/example/pubspec.lock
+++ b/packages/import_guard/example/pubspec.lock
@@ -103,7 +103,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:

--- a/packages/import_guard/example/pubspec.lock
+++ b/packages/import_guard/example/pubspec.lock
@@ -5,34 +5,34 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
+      sha256: a49d6cf99e8d8e7a8e93668d09ced0bbdb954d0b4fccc2f5f9241c6b87fad95c
       url: "https://pub.dev"
     source: hosted
-    version: "91.0.0"
+    version: "99.0.0"
   analysis_server_plugin:
     dependency: transitive
     description:
       name: analysis_server_plugin
-      sha256: "26844e7f977087567135d62532b67d5639fe206c5194c3f410ba75e1a04a2747"
+      sha256: "3960b28ee740004df39f85d5ebfc91785f7a90e51fd7c9a185e86a36b2f581b4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3"
+    version: "0.3.14"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: a40a0cee526a7e1f387c6847bd8a5ccbf510a75952ef8a28338e989558072cb0
+      sha256: "663efa951fb8a45e06f491223a604c93820598f20e6a99c25617a1576065e8b7"
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.0"
+    version: "12.1.0"
   analyzer_plugin:
     dependency: transitive
     description:
       name: analyzer_plugin
-      sha256: "08cfefa90b4f4dd3b447bda831cecf644029f9f8e22820f6ee310213ebe2dd53"
+      sha256: "0057a98d64d7bb872b0c87dff6e73d2c2d80c77156e7a03f127a26f8aa240649"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.10"
+    version: "0.14.8"
   args:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   collection:
     dependency: transitive
     description:
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
+      sha256: a4c1ccfee44c7e75ed80484071a5c142a385345e658fd8bd7c4b5c97e7198f98
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.8"
   file:
     dependency: transitive
     description:
@@ -108,10 +108,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: df0c643f44ad098eb37988027a8e2b2b5a031fd3977f06bbfd3a76637e8df739
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.2"
   package_config:
     dependency: transitive
     description:
@@ -140,10 +140,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   string_scanner:
     dependency: transitive
     description:
@@ -172,10 +172,10 @@ packages:
     dependency: transitive
     description:
       name: watcher
-      sha256: f52385d4f73589977c80797e60fe51014f7f2b957b5e9a62c3f6ada439889249
+      sha256: "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   yaml:
     dependency: transitive
     description:
@@ -188,9 +188,9 @@ packages:
     dependency: transitive
     description:
       name: yaml_edit
-      sha256: ec709065bb2c911b336853b67f3732dd13e0336bd065cc2f1061d7610ddf45e3
+      sha256: "07c9e63ba42519745182b88ca12264a7ba2484d8239958778dfe4d44fe760488"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
 sdks:
   dart: ">=3.10.0 <4.0.0"

--- a/packages/import_guard/pubspec.lock
+++ b/packages/import_guard/pubspec.lock
@@ -5,34 +5,34 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
+      sha256: a49d6cf99e8d8e7a8e93668d09ced0bbdb954d0b4fccc2f5f9241c6b87fad95c
       url: "https://pub.dev"
     source: hosted
-    version: "91.0.0"
+    version: "99.0.0"
   analysis_server_plugin:
     dependency: "direct main"
     description:
       name: analysis_server_plugin
-      sha256: "26844e7f977087567135d62532b67d5639fe206c5194c3f410ba75e1a04a2747"
+      sha256: "3960b28ee740004df39f85d5ebfc91785f7a90e51fd7c9a185e86a36b2f581b4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3"
+    version: "0.3.14"
   analyzer:
     dependency: "direct main"
     description:
       name: analyzer
-      sha256: a40a0cee526a7e1f387c6847bd8a5ccbf510a75952ef8a28338e989558072cb0
+      sha256: "663efa951fb8a45e06f491223a604c93820598f20e6a99c25617a1576065e8b7"
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.0"
+    version: "12.1.0"
   analyzer_plugin:
     dependency: transitive
     description:
       name: analyzer_plugin
-      sha256: "08cfefa90b4f4dd3b447bda831cecf644029f9f8e22820f6ee310213ebe2dd53"
+      sha256: "0057a98d64d7bb872b0c87dff6e73d2c2d80c77156e7a03f127a26f8aa240649"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.10"
+    version: "0.14.8"
   args:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
+      sha256: a4c1ccfee44c7e75ed80484071a5c142a385345e658fd8bd7c4b5c97e7198f98
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.8"
   file:
     dependency: transitive
     description:
@@ -165,18 +165,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: df0c643f44ad098eb37988027a8e2b2b5a031fd3977f06bbfd3a76637e8df739
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.2"
   mime:
     dependency: transitive
     description:
@@ -277,10 +277,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
@@ -317,26 +317,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "77cc98ea27006c84e71a7356cf3daf9ddbde2d91d84f77dbfe64cf0e4d9611ae"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.28.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: f1072617a6657e5fc09662e721307f7fb009b4ed89b19f47175d11d5254a62d4
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.14"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:
@@ -357,18 +357,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "046d3928e16fa4dc46e8350415661755ab759d9fc97fc21b5ab295f71e4f0499"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.1.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: f52385d4f73589977c80797e60fe51014f7f2b957b5e9a62c3f6ada439889249
+      sha256: "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   web:
     dependency: transitive
     description:
@@ -413,9 +413,9 @@ packages:
     dependency: transitive
     description:
       name: yaml_edit
-      sha256: ec709065bb2c911b336853b67f3732dd13e0336bd065cc2f1061d7610ddf45e3
+      sha256: "07c9e63ba42519745182b88ca12264a7ba2484d8239958778dfe4d44fe760488"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0 <4.0.0"

--- a/packages/import_guard/pubspec.yaml
+++ b/packages/import_guard/pubspec.yaml
@@ -1,6 +1,6 @@
 name: import_guard
 description: An analyzer plugin to guard imports between folders. Enforce clean architecture layer dependencies with configurable deny rules.
-version: 0.1.0
+version: 0.2.0
 repository: https://github.com/ryota-kishimoto/import_guard/tree/main/packages/import_guard
 issue_tracker: https://github.com/ryota-kishimoto/import_guard/issues
 topics:
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   analysis_server_plugin: ">=0.3.0 <1.0.0"
-  analyzer: ">=8.2.0 <12.0.0"
+  analyzer: ">=8.2.0 <13.0.0"
   path: ^1.9.0
   yaml: ^3.1.0
 


### PR DESCRIPTION
## Summary
- Widen analyzer constraint from `<12.0.0` to `<13.0.0` so import_guard can coexist with other analyzer plugins pinned to analyzer 12.x.
- Bump version to 0.2.0 and update CHANGELOG.
- No source changes: package already compiles cleanly against analyzer 12.1.0.
- Upgrade `pubspec.lock` of both the package and its example to analyzer 12.1.0 so CI verifies behavior under the new upper bound.

## Why
When `import_guard` (analyzer <12) and another analyzer-plugin pinned to analyzer 12 (e.g. `analysis_server_plugin` 0.3.14 based plugins) are enabled together in `analysis_options.yaml`, pub version solving inside the analyzer plugin isolate fails:

```
Because every version of weather_linter from path depends on analyzer ^12.0.0
and import_guard >=0.1.0 depends on analyzer >=8.2.0 <12.0.0,
weather_linter from path is incompatible with import_guard >=0.1.0.
```

The Dart analyzer surfaces this as `Bad state: The analysis server crashed unexpectedly`, which is hard to diagnose. Widening the constraint allows both plugins to share analyzer 12.x and resolves the crash.

## Verification
Resolved with analyzer 12.1.0 and exercised end-to-end:

- [x] `dart pub upgrade` in `packages/import_guard` → analyzer 12.1.0 (committed in `pubspec.lock`)
- [x] `dart pub upgrade` in `packages/import_guard/example` → analyzer 12.1.0 (committed in `example/pubspec.lock`)
- [x] `dart test` in `packages/import_guard`: **50/50 passed**
- [x] `dart analyze` in `packages/import_guard/example` under analyzer 12.1.0: plugin loads and emits the expected 2 import_guard diagnostics (no regressions)
- [x] Reproduced and fixed the coexistence crash against a consumer project (おてがる天気) by swapping in this branch via `path:` dependency

## Compatibility
- SDK: `^3.9.0` (unchanged)
- analyzer: `>=8.2.0 <13.0.0` (widened)
- analysis_server_plugin: `>=0.3.0 <1.0.0` (unchanged)

No breaking API changes for consumers.